### PR TITLE
TextField 데이터 바인딩 문제 해결

### DIFF
--- a/Connect/Start/LoginView.swift
+++ b/Connect/Start/LoginView.swift
@@ -140,23 +140,37 @@ struct LoginView: View {
 }
 
 struct CustomTextField: UIViewRepresentable {
-    @Binding var text: String
-    var placeholder: String
-    
-    func makeUIView(context: Context) -> UITextField {
-        let textField = UITextField()
-        textField.textColor = UIColor.white // Text color
-        textField.attributedPlaceholder = NSAttributedString(string: placeholder,
-                                                             attributes: [NSAttributedString.Key.foregroundColor: UIColor.white]) // Placeholder color
-        return textField
+  @Binding var text: String
+  var placeholder: String
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.textColor = UIColor.white // Text color
+    textField.attributedPlaceholder = NSAttributedString(string: placeholder,
+                                                         attributes: [NSAttributedString.Key.foregroundColor: UIColor.white]) // Placeholder color
+    textField.delegate = context.coordinator
+    return textField
+  }
+
+  func updateUIView(_ uiView: UITextField, context: Context) {
+    uiView.text = text
+  }
+
+  class Coordinator: NSObject {
+    var text: Binding<String>
+
+    init(_ text: Binding<String>) {
+      self.text = text
     }
-    
-    func updateUIView(_ uiView: UITextField, context: Context) {
-        uiView.text = text
-    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator($text)
+  }
 }
 
 struct CustomTextField1: UIViewRepresentable {
+    // TODO: - 지금은 text만 쓰이는 걸로 보여요! text1, text2, text3 도 밖에 뷰랑 바인딩 되어야 한다면 이것도 `class Coordinator: NSObject` 아래에서 text한 것처럼 똑같이 바인딩 해주셔야 합니다!
     @Binding var text: String
     @Binding var text1: String
     @Binding var text2: String
@@ -169,12 +183,37 @@ struct CustomTextField1: UIViewRepresentable {
         textField.textColor = UIColor.black // Text color
         textField.attributedPlaceholder = NSAttributedString(string: placeholder,
                                                              attributes: [NSAttributedString.Key.foregroundColor: UIColor.black]) // Placeholder color
+        textField.delegate = context.coordinator
         return textField
     }
     
     func updateUIView(_ uiView: UITextField, context: Context) {
         uiView.text = text
     }
+
+    class Coordinator: NSObject {
+      var text: Binding<String>
+
+      init(_ text: Binding<String>) {
+        self.text = text
+      }
+    }
+
+    func makeCoordinator() -> Coordinator {
+      Coordinator($text)
+    }
+}
+
+extension CustomTextField.Coordinator: UITextFieldDelegate {
+  func textFieldDidChangeSelection(_ textField: UITextField) {
+    text.wrappedValue = textField.text ?? ""
+  }
+}
+
+extension CustomTextField1.Coordinator: UITextFieldDelegate {
+  func textFieldDidChangeSelection(_ textField: UITextField) {
+    text.wrappedValue = textField.text ?? ""
+  }
 }
 
 struct LoginView_Previews: PreviewProvider {


### PR DESCRIPTION
### 문제 상황
- CustomTextField에서 UIRepresentable을 상속받아 사용하고 있는데, 이 때 SigninView에서 사용하는 text를 동기화 해주기 위해서는 Coordinator를 선언해야 합니다.

<img width="707" alt="image" src="https://github.com/daolkong/Connect/assets/59143479/4370a0aa-a67c-4c4a-9617-e287cba4b2b7">

UIRepresentable은 SwiftUI에서 부족한 기능을 UIKit 컴포넌트를 가져와서 활용하는 방법을 제공해줍니다.
해당 상속받은 뷰를 사용할 때, UIRepresentable에서 데이터를 어떻게 처리하는 지 알고 사용하기를 권장드려요 :)

### 참고자료

https://munokkim.medium.com/uiviewrepresentable을-이용하여-swiftui에서-uitextview를-사용하기-97cae61d2471

- 해당 블로그를 이해하기 위해서는 Delegate라는 UIKit에서 널리 활용하는 개념을 이해해야 하는데, 처음엔 다들 많이 어려워 하세요.
우선은 델리게이트라는 것이 있구나 라고 알고만 넘어가셔도 좋습니다.